### PR TITLE
(RPC version): POST data to backend instead

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -89,7 +89,7 @@ export default new Vuex.Store({
       try {
         const { file: fileId, recno, source, studentId } = payload
         context.commit('SET_PDF_FILE_LOADING', recno)
-        const { data: { file: base64File } } = await getData(`/files/${source}/${fileId}/${recno}/${studentId}`)
+        const { data: { file: base64File } } = await getData('/files', { source, fileId, recno, studentId })
         const pdfFile = base64toUint8(base64File)
         const { numPages } = await pdf.createLoadingTask(pdfFile)
         context.commit('SET_PDF_FILE', { data: pdfFile, numPages, fileId })

--- a/src/views/View.vue
+++ b/src/views/View.vue
@@ -11,7 +11,7 @@
             <v-btn to="/" class="ma-5" color="primary" dark fab small>
               <v-icon>mdi-arrow-left</v-icon>
             </v-btn>
-            <h3 class="headline">{{ loading ? 'Laster ...' : student.fullName }}</h3>
+            <h3 class="headline">{{ !student.fullName ? 'Laster ...' : student.fullName }}</h3>
           </v-card-title>
 
           <v-card-text>


### PR DESCRIPTION
When getting a file from the backend, the parameters and identifiers of the file should be passed in a POST request. GET is not suitable for long texts..